### PR TITLE
Refactor TWidgets into Containers(TWidgets)

### DIFF
--- a/applications/etop/CMakeLists.txt
+++ b/applications/etop/CMakeLists.txt
@@ -1,2 +1,4 @@
 add_executable(etop etop.c)
-target_link_libraries(etop eco_perf)
+target_link_libraries(etop etop_widgets eco_perf)
+
+add_subdirectory(widgets)

--- a/applications/etop/widgets/CMakeLists.txt
+++ b/applications/etop/widgets/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(etop_widgets
+    cpu_info.h cpu_info.c
+)

--- a/applications/etop/widgets/cpu_info.c
+++ b/applications/etop/widgets/cpu_info.c
@@ -1,0 +1,62 @@
+#include "cpu_info.h"
+#include <stdlib.h>
+
+void init_cpu_info_twidget(
+    cpu_info_twidget_t *widget);
+
+void init_cpu_info_twidget_data(
+    cpu_info_twidget_data_t *data);
+
+void init_cpu_info_twidget_config(
+    cpu_info_twidget_config_t *config);
+
+void _update_cpu_data_widget(cpu_info_twidget_t *widget);
+
+void init_cpu_info_twidget_container(
+    cpu_info_twidget_container_t *container)
+{
+    init_twidget(&container->widget);
+    init_text_line_twidget(&container->title_widget, "");
+    init_cpu_info_twidget(&container->cpu_widget);
+}
+
+void set_cpu_info_twidget_data(
+    cpu_info_twidget_t *widget,
+    cpu_core_data_t *data);
+
+void init_cpu_info_twidget(
+    cpu_info_twidget_t *widget)
+{
+    init_twidget(widget);
+    widget->update = _update_cpu_data_widget;
+    widget->size.x = 50;
+    widget->size.y = 1;
+    widget->fixed_size.y = 1;
+}
+
+void init_cpu_info_twidget_data(
+    cpu_info_twidget_data_t *data)
+{
+    data->title = "";
+    data->cpu_data = NULL;
+    init_percent_bar_data(&data->percent_bar_data);
+}
+
+void init_cpu_info_twidget_config(
+    cpu_info_twidget_config_t *config)
+{
+    init_twidget_linear_layout(&config->layout, CT_HORIZONTAL);
+    config->layout.config.spacing = 1;
+    init_percent_bar_config(&config->percent_bar_config);
+}
+
+void _update_cpu_data_widget(cpu_info_twidget_t *widget)
+{
+    cpu_info_twidget_data_t *data = (cpu_info_twidget_data_t *)(widget->data);
+    percent_bar_data_t *bar_data = &data->percent_bar_data;
+    cpu_core_data_t const *core_data = data->cpu_data;
+    init_percent_bar_data(bar_data);
+    add_percent_data(bar_data, core_data->user_ratio, CT_GREEN);
+    add_percent_data(bar_data, core_data->sys_ratio, CT_BLUE);
+    add_percent_data(bar_data, core_data->nice_ratio, CT_YELLOW);
+}

--- a/applications/etop/widgets/cpu_info.h
+++ b/applications/etop/widgets/cpu_info.h
@@ -1,0 +1,47 @@
+#ifndef ETOP_CPU_INFO_TWIDGET_H_INCLUDED
+#define ETOP_CPU_INFO_TWIDGET_H_INCLUDED
+
+#include "eco_perf/cute_terminal/widgets/layouts/linear_layout.h"
+#include "eco_perf/cute_terminal/widgets/percent_bar.h"
+#include "eco_perf/cute_terminal/widgets/text_line.h"
+#include "eco_perf/cute_terminal/widgets/twidget.h"
+#include "eco_perf/metrics/cpu_usage.h"
+
+typedef twidget_t cpu_info_twidget_t;
+
+typedef struct CPUInfoTwidgetData
+{
+    char const *title;
+    cpu_core_data_t *cpu_data;
+    percent_bar_data_t percent_bar_data;
+} cpu_info_twidget_data_t;
+
+typedef struct CPUInfoTwidgetConfig
+{
+    twidget_linear_layout_t layout;
+    percent_bar_config_t percent_bar_config;
+} cpu_info_twidget_config_t;
+
+typedef struct CPUInfoTwidgetContainer
+{
+    // Main widget
+    twidget_t widget;
+
+    // Sub-widgets
+    text_line_twidget_t title_widget;
+    cpu_info_twidget_t cpu_widget;
+
+    // Data and config
+    cpu_info_twidget_data_t data;
+    cpu_info_twidget_config_t config;
+
+} cpu_info_twidget_container_t;
+
+void init_cpu_info_twidget_container(
+    cpu_info_twidget_container_t *container);
+
+void set_cpu_info_twidget_data(
+    cpu_info_twidget_t *widget,
+    cpu_core_data_t *data);
+
+#endif

--- a/eco_perf/cute_terminal/terminal_application.c
+++ b/eco_perf/cute_terminal/terminal_application.c
@@ -26,3 +26,9 @@ void run_terminal_application(terminal_application_t *app)
         update_terminal_application(app);
     }
 }
+
+void free_terminal_application(terminal_application_t *app)
+{
+    app->terminal.draw_self(&app->terminal);
+    free_twidget(&app->terminal);
+}

--- a/eco_perf/cute_terminal/terminal_application.h
+++ b/eco_perf/cute_terminal/terminal_application.h
@@ -17,4 +17,6 @@ void update_terminal_application(terminal_application_t *app);
 
 void run_terminal_application(terminal_application_t *app);
 
+void free_terminal_application(terminal_application_t *app);
+
 #endif

--- a/eco_perf/cute_terminal/widgets/layouts/compute_layout.c
+++ b/eco_perf/cute_terminal/widgets/layouts/compute_layout.c
@@ -23,7 +23,7 @@ void _compute_layout_stretching(
         {
             available_size -= child->size_v[direction];
         }
-        else
+        else if (!child->floating)
         {
             ++*n_stretchable_elements;
         }
@@ -219,7 +219,7 @@ void _apply_perpendicular_to_layout(
         twidget_t *child = children->widgets[i];
         if (child->floating)
         {
-            return;
+            continue;
         }
         if (!config->auto_children_resize || child->fixed_size_v[perpendicular])
         {

--- a/eco_perf/cute_terminal/widgets/percent_bar.c
+++ b/eco_perf/cute_terminal/widgets/percent_bar.c
@@ -54,3 +54,14 @@ void init_percent_bar_twidget(
     percent_bar->update = _update_percent_bar;
     percent_bar->draw_self = _draw_percent_bar;
 }
+
+void init_percent_bar_twidget_container(
+    percent_bar_twidget_container_t *container)
+{
+    init_percent_bar_config(&container->config);
+    init_percent_bar_data(&container->data);
+    init_percent_bar_twidget(
+        &container->widget,
+        &container->data,
+        &container->config);
+}

--- a/eco_perf/cute_terminal/widgets/percent_bar.h
+++ b/eco_perf/cute_terminal/widgets/percent_bar.h
@@ -11,4 +11,14 @@ void init_percent_bar_twidget(
     percent_bar_data_t *data,
     percent_bar_config_t *config);
 
+typedef struct PercentBarTwidgetContainer
+{
+    percent_bar_twidget_t widget;
+    percent_bar_config_t config;
+    percent_bar_data_t data;
+} percent_bar_twidget_container_t;
+
+void init_percent_bar_twidget_container(
+    percent_bar_twidget_container_t *container);
+
 #endif

--- a/eco_perf/cute_terminal/widgets/twidget.c
+++ b/eco_perf/cute_terminal/widgets/twidget.c
@@ -51,6 +51,7 @@ void init_twidget(twidget_t *widget)
     init_term_vector(&widget->fixed_size);
     init_twidget_array(&widget->children);
     widget->config = NULL;
+    widget->free = NULL;
 
     widget->get_origin = _default_get_origin;
     widget->update = _default_update;
@@ -135,13 +136,20 @@ void remove_twidget_child(
 
 void free_twidget(twidget_t *widget)
 {
-    if (!widget->children.widgets)
+    if (!widget)
     {
         return;
     }
-    for (int i = 0; i != widget->children.size; ++i)
+    if (widget->children.widgets)
     {
-        free_twidget(widget->children.widgets[i]);
+        for (int i = 0; i != widget->children.size; ++i)
+        {
+            free_twidget(widget->children.widgets[i]);
+        }
+        free_twidget_array(&widget->children);
     }
-    free_twidget_array(&widget->children);
+    if (widget->free)
+    {
+        widget->free(widget);
+    }
 }

--- a/eco_perf/cute_terminal/widgets/twidget.h
+++ b/eco_perf/cute_terminal/widgets/twidget.h
@@ -35,6 +35,8 @@ typedef struct TWidget
         struct TWidget const *widget);
 
     int (*draw_self)(struct TWidget const *widget);
+
+    void (*free)(struct TWidget *widget);
 } twidget_t;
 
 void init_twidget(twidget_t *widget);


### PR DESCRIPTION
The polymorphism necessary for the widget system to work has the consequence to require a lot of lines of code to define all the necessary objects on the stack (or allocate a lot of different objects, complicating the code and the user interface).

This PR modifies the behavior of `cute-terminal` in the following way:
 - Now only one container per widget must be created on the stack (or allocated by the user if necessary)
 - The container contains the widget, data and configuration accessible safely and directly by the user.
 - The container initialization takes car of initializing al members correctly in a unique C source file.

The user interface should therefore resemble something like
``` c
    twidget_container_1_t container_1;
    init_twidget_container_1(&container_1);
    container_1.config.layout.spacing = 3; 

    twidget_container_2_t container_2;
    init_twidget_container_2(&container_2);
    container_2.data.title = "Some title for my widget";

    add_twidget_child(&container_1.twidget, &container_2.twidget);
    // etc
```