### PR TITLE
Behavior change twidget -> manager(twidget)

### DIFF
--- a/applications/etop/CMakeLists.txt
+++ b/applications/etop/CMakeLists.txt
@@ -1,2 +1,4 @@
 add_executable(etop etop.c)
-target_link_libraries(etop eco_perf)
+target_link_libraries(etop etop_widgets eco_perf)
+
+add_subdirectory(widgets)

--- a/applications/etop/widgets/CMakeLists.txt
+++ b/applications/etop/widgets/CMakeLists.txt
@@ -1,0 +1,3 @@
+add_library(etop_widgets
+    cpu_info.h cpu_info.c
+)

--- a/applications/etop/widgets/cpu_info.c
+++ b/applications/etop/widgets/cpu_info.c
@@ -1,6 +1,7 @@
 #include "cpu_info.h"
 #include <stdlib.h>
 
+/*
 void init_cpu_info_twidget(
     cpu_info_twidget_t *widget);
 
@@ -60,3 +61,5 @@ void _update_cpu_data_widget(cpu_info_twidget_t *widget)
     add_percent_data(bar_data, core_data->sys_ratio, CT_BLUE);
     add_percent_data(bar_data, core_data->nice_ratio, CT_YELLOW);
 }
+
+*/

--- a/applications/etop/widgets/cpu_info.c
+++ b/applications/etop/widgets/cpu_info.c
@@ -1,0 +1,62 @@
+#include "cpu_info.h"
+#include <stdlib.h>
+
+void init_cpu_info_twidget(
+    cpu_info_twidget_t *widget);
+
+void init_cpu_info_twidget_data(
+    cpu_info_twidget_data_t *data);
+
+void init_cpu_info_twidget_config(
+    cpu_info_twidget_config_t *config);
+
+void _update_cpu_data_widget(cpu_info_twidget_t *widget);
+
+void init_cpu_info_twidget_container(
+    cpu_info_twidget_container_t *container)
+{
+    init_twidget(&container->widget);
+    init_text_line_twidget(&container->title_widget, "");
+    init_cpu_info_twidget(&container->cpu_widget);
+}
+
+void set_cpu_info_twidget_data(
+    cpu_info_twidget_t *widget,
+    cpu_core_data_t *data);
+
+void init_cpu_info_twidget(
+    cpu_info_twidget_t *widget)
+{
+    init_twidget(widget);
+    widget->update = _update_cpu_data_widget;
+    widget->size.x = 50;
+    widget->size.y = 1;
+    widget->fixed_size.y = 1;
+}
+
+void init_cpu_info_twidget_data(
+    cpu_info_twidget_data_t *data)
+{
+    data->title = "";
+    data->cpu_data = NULL;
+    init_percent_bar_data(&data->percent_bar_data);
+}
+
+void init_cpu_info_twidget_config(
+    cpu_info_twidget_config_t *config)
+{
+    init_twidget_linear_layout(&config->layout, CT_HORIZONTAL);
+    config->layout.config.spacing = 1;
+    init_percent_bar_config(&config->percent_bar_config);
+}
+
+void _update_cpu_data_widget(cpu_info_twidget_t *widget)
+{
+    cpu_info_twidget_data_t *data = (cpu_info_twidget_data_t *)(widget->data);
+    percent_bar_data_t *bar_data = &data->percent_bar_data;
+    cpu_core_data_t const *core_data = data->cpu_data;
+    init_percent_bar_data(bar_data);
+    add_percent_data(bar_data, core_data->user_ratio, CT_GREEN);
+    add_percent_data(bar_data, core_data->sys_ratio, CT_BLUE);
+    add_percent_data(bar_data, core_data->nice_ratio, CT_YELLOW);
+}

--- a/applications/etop/widgets/cpu_info.h
+++ b/applications/etop/widgets/cpu_info.h
@@ -7,6 +7,7 @@
 #include "eco_perf/cute_terminal/widgets/twidget.h"
 #include "eco_perf/metrics/cpu_usage.h"
 
+/*
 typedef twidget_t cpu_info_twidget_t;
 
 typedef struct CPUInfoTwidgetData
@@ -43,5 +44,5 @@ void init_cpu_info_twidget_container(
 void set_cpu_info_twidget_data(
     cpu_info_twidget_t *widget,
     cpu_core_data_t *data);
-
+*/
 #endif

--- a/applications/etop/widgets/cpu_info.h
+++ b/applications/etop/widgets/cpu_info.h
@@ -1,0 +1,47 @@
+#ifndef ETOP_CPU_INFO_TWIDGET_H_INCLUDED
+#define ETOP_CPU_INFO_TWIDGET_H_INCLUDED
+
+#include "eco_perf/cute_terminal/widgets/layouts/linear_layout.h"
+#include "eco_perf/cute_terminal/widgets/percent_bar.h"
+#include "eco_perf/cute_terminal/widgets/text_line.h"
+#include "eco_perf/cute_terminal/widgets/twidget.h"
+#include "eco_perf/metrics/cpu_usage.h"
+
+typedef twidget_t cpu_info_twidget_t;
+
+typedef struct CPUInfoTwidgetData
+{
+    char const *title;
+    cpu_core_data_t *cpu_data;
+    percent_bar_data_t percent_bar_data;
+} cpu_info_twidget_data_t;
+
+typedef struct CPUInfoTwidgetConfig
+{
+    twidget_linear_layout_t layout;
+    percent_bar_config_t percent_bar_config;
+} cpu_info_twidget_config_t;
+
+typedef struct CPUInfoTwidgetContainer
+{
+    // Main widget
+    twidget_t widget;
+
+    // Sub-widgets
+    text_line_twidget_t title_widget;
+    cpu_info_twidget_t cpu_widget;
+
+    // Data and config
+    cpu_info_twidget_data_t data;
+    cpu_info_twidget_config_t config;
+
+} cpu_info_twidget_container_t;
+
+void init_cpu_info_twidget_container(
+    cpu_info_twidget_container_t *container);
+
+void set_cpu_info_twidget_data(
+    cpu_info_twidget_t *widget,
+    cpu_core_data_t *data);
+
+#endif

--- a/eco_perf/cute_terminal/terminal_application.c
+++ b/eco_perf/cute_terminal/terminal_application.c
@@ -5,23 +5,26 @@
 
 void init_terminal_application(
     terminal_application_t *app,
-    twidget_t *main_widget)
+    twidget_t *main_twidget)
 {
-    init_terminal_twidget(&app->terminal, main_widget);
+    init_terminal_tmanager(&app->terminal_manager, main_twidget);
     app->sleep_duration = CT_DEFAULT_SLEEP_DURATION;
+    app->is_open = 0;
 }
 
 void update_terminal_application(terminal_application_t *app)
 {
-    update_twidget(&app->terminal);
-    draw_twidget(&app->terminal);
+    twidget_t *terminal_twidget = &app->terminal_manager.terminal_container_twidget;
+    update_twidget(terminal_twidget);
+    draw_twidget(terminal_twidget);
     fflush(stdout);
     usleep(app->sleep_duration * 1e6);
 }
 
 void run_terminal_application(terminal_application_t *app)
 {
-    while (1)
+    app->is_open = 1;
+    while (app->is_open)
     {
         update_terminal_application(app);
     }
@@ -29,6 +32,7 @@ void run_terminal_application(terminal_application_t *app)
 
 void free_terminal_application(terminal_application_t *app)
 {
-    app->terminal.draw_self(&app->terminal);
-    free_twidget(&app->terminal);
+    twidget_t *terminal_twidget = &app->terminal_manager.terminal_container_twidget;
+    terminal_twidget->interface->draw(terminal_twidget);
+    free_twidget(terminal_twidget);
 }

--- a/eco_perf/cute_terminal/terminal_application.c
+++ b/eco_perf/cute_terminal/terminal_application.c
@@ -26,3 +26,9 @@ void run_terminal_application(terminal_application_t *app)
         update_terminal_application(app);
     }
 }
+
+void free_terminal_application(terminal_application_t *app)
+{
+    app->terminal.draw_self(&app->terminal);
+    free_twidget(&app->terminal);
+}

--- a/eco_perf/cute_terminal/terminal_application.h
+++ b/eco_perf/cute_terminal/terminal_application.h
@@ -5,7 +5,8 @@
 
 typedef struct TerminalApplication
 {
-    terminal_twidget_t terminal;
+    int is_open;
+    terminal_tmanager_t terminal_manager;
     float sleep_duration; // in seconds
 } terminal_application_t;
 

--- a/eco_perf/cute_terminal/terminal_application.h
+++ b/eco_perf/cute_terminal/terminal_application.h
@@ -17,4 +17,6 @@ void update_terminal_application(terminal_application_t *app);
 
 void run_terminal_application(terminal_application_t *app);
 
+void free_terminal_application(terminal_application_t *app);
+
 #endif

--- a/eco_perf/cute_terminal/widgets/CMakeLists.txt
+++ b/eco_perf/cute_terminal/widgets/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_library(widgets
     twidget.h twidget.c
-    twidget_interface.h
+    twidget_interface.h twidget_interface.c
     box.h box.c
     terminal.h terminal.c
     percent_bar.h percent_bar.c

--- a/eco_perf/cute_terminal/widgets/CMakeLists.txt
+++ b/eco_perf/cute_terminal/widgets/CMakeLists.txt
@@ -1,5 +1,6 @@
 add_library(widgets
     twidget.h twidget.c
+    twidget_interface.h
     box.h box.c
     terminal.h terminal.c
     percent_bar.h percent_bar.c

--- a/eco_perf/cute_terminal/widgets/box.c
+++ b/eco_perf/cute_terminal/widgets/box.c
@@ -4,6 +4,21 @@
 #include "../terminal/cursor.h"
 #include <stdio.h>
 
+void _draw_box(twidget_t *box);
+
+const twidget_interface_t box_twidget_interface = {
+    default_twidget_update,
+    _draw_box,
+    default_twidget_free};
+
+void init_box_tmanager(
+    box_tmanager_t *box)
+{
+    init_twidget(&box->twidget);
+    box->twidget.config = (void *)&box->config;
+    box->twidget.interface = &box_twidget_interface;
+}
+
 void _new_box_line(int line_size)
 {
     move_cursor_down(1);
@@ -24,7 +39,7 @@ void _reset_box_cursor_pos(terminal_vector_t box_size)
     move_cursor_up(box_size.y);
 }
 
-int _draw_box(box_twidget_t const *box)
+void _draw_box(twidget_t *box)
 {
     char background = ' ';
     if (box->config)
@@ -48,20 +63,4 @@ int _draw_box(box_twidget_t const *box)
     fill_str(buffer, '-', lx);
     printf("%s", buffer);
     _reset_box_cursor_pos(box->size);
-
-    return 1;
-}
-
-void init_box_twidget(
-    box_twidget_t *box)
-{
-    init_twidget(box);
-    box->draw_self = _draw_box;
-}
-
-void set_box_twidget_config(
-    box_twidget_t *box,
-    box_twidget_config_t *config)
-{
-    box->config = (void *)config;
 }

--- a/eco_perf/cute_terminal/widgets/box.c
+++ b/eco_perf/cute_terminal/widgets/box.c
@@ -15,6 +15,7 @@ void init_box_tmanager(
     box_tmanager_t *box)
 {
     init_twidget(&box->twidget);
+    box->config.background = ' ';
     box->twidget.config = (void *)&box->config;
     box->twidget.interface = &box_twidget_interface;
 }

--- a/eco_perf/cute_terminal/widgets/box.h
+++ b/eco_perf/cute_terminal/widgets/box.h
@@ -3,18 +3,20 @@
 
 #include "twidget.h"
 
-typedef twidget_t box_twidget_t;
-
 typedef struct BoxTWidgetConfig
 {
     char background;
 } box_twidget_config_t;
 
-void init_box_twidget(
-    box_twidget_t *box);
+typedef struct BoxTManager
+{
+    twidget_t twidget;
+    box_twidget_config_t config;
+} box_tmanager_t;
 
-void set_box_twidget_config(
-    box_twidget_t *box,
-    box_twidget_config_t *config);
+extern const twidget_interface_t box_twidget_interface;
+
+void init_box_tmanager(
+    box_tmanager_t *box);
 
 #endif

--- a/eco_perf/cute_terminal/widgets/layouts/compute_layout.c
+++ b/eco_perf/cute_terminal/widgets/layouts/compute_layout.c
@@ -23,7 +23,7 @@ void _compute_layout_stretching(
         {
             available_size -= child->size_v[direction];
         }
-        else
+        else if (!child->floating)
         {
             ++*n_stretchable_elements;
         }
@@ -219,7 +219,7 @@ void _apply_perpendicular_to_layout(
         twidget_t *child = children->widgets[i];
         if (child->floating)
         {
-            return;
+            continue;
         }
         if (!config->auto_children_resize || child->fixed_size_v[perpendicular])
         {

--- a/eco_perf/cute_terminal/widgets/percent_bar.c
+++ b/eco_perf/cute_terminal/widgets/percent_bar.c
@@ -54,3 +54,14 @@ void init_percent_bar_twidget(
     percent_bar->update = _update_percent_bar;
     percent_bar->draw_self = _draw_percent_bar;
 }
+
+void init_percent_bar_twidget_container(
+    percent_bar_twidget_container_t *container)
+{
+    init_percent_bar_config(&container->config);
+    init_percent_bar_data(&container->data);
+    init_percent_bar_twidget(
+        &container->widget,
+        &container->data,
+        &container->config);
+}

--- a/eco_perf/cute_terminal/widgets/percent_bar.c
+++ b/eco_perf/cute_terminal/widgets/percent_bar.c
@@ -4,16 +4,34 @@
 #include "../terminal/cursor.h"
 #include <stdio.h>
 
-void _update_percent_bar(percent_bar_twidget_t *percent_bar)
+void _update_percent_bar(twidget_t *percent_bar);
+void _draw_percent_bar(twidget_t *percent_bar);
+
+const twidget_interface_t percent_bar_twidget_interface = {
+    _update_percent_bar,
+    _draw_percent_bar,
+    default_twidget_free};
+
+void init_percent_bar_twidget(
+    twidget_t *percent_bar,
+    percent_bar_data_t *data,
+    percent_bar_config_t *config)
 {
-    percent_bar_config_t *config = (percent_bar_config_t *)percent_bar->config;
-    int percent_size = 6 * (config->percent_mode == CT_PERCENT_OUT);
-    config->bar_size = percent_bar->size.x - 2 - percent_size;
-    CT_ASSERT(
-        config->bar_size > 0,
-        CT_VALUE_ERROR,
-        "Widget of size %d is too small for percent bar widget.",
-        percent_bar->size.x)
+}
+
+void init_percent_bar_tmanager(
+    percent_bar_tmanager_t *manager)
+{
+    init_percent_bar_config(&manager->config);
+    init_percent_bar_data(&manager->data);
+
+    twidget_t *twidget = &manager->twidget;
+    init_twidget(twidget);
+    twidget->size.y = 1;
+    twidget->fixed_size.y = 1;
+    twidget->data = (void *)&manager->data;
+    twidget->config = (void *)&manager->config;
+    twidget->interface = &percent_bar_twidget_interface;
 }
 
 void _set_bar_cursor_pos(terminal_vector_t bar_pos)
@@ -30,7 +48,19 @@ void _reset_bar_cursor_pos(
     move_cursor_left(bar_pos.x + str_size);
 }
 
-int _draw_percent_bar(percent_bar_twidget_t const *percent_bar)
+void _update_percent_bar(twidget_t *percent_bar)
+{
+    percent_bar_config_t *config = (percent_bar_config_t *)percent_bar->config;
+    int percent_size = 6 * (config->percent_mode == CT_PERCENT_OUT);
+    config->bar_size = percent_bar->size.x - 2 - percent_size;
+    CT_ASSERT(
+        config->bar_size > 0,
+        CT_VALUE_ERROR,
+        "Widget of size %d is too small for percent bar widget.",
+        percent_bar->size.x)
+}
+
+void _draw_percent_bar(twidget_t *percent_bar)
 {
     char buffer[CT_MAX_PERCENT_BAR_SIZE];
     percent_bar_data_t *data = (percent_bar_data_t *)percent_bar->data;
@@ -39,29 +69,4 @@ int _draw_percent_bar(percent_bar_twidget_t const *percent_bar)
     int line_size = get_effective_string_length(buffer);
     printf("%s", buffer);
     move_cursor_left(line_size);
-    return 1;
-}
-
-void init_percent_bar_twidget(
-    percent_bar_twidget_t *percent_bar,
-    percent_bar_data_t *data,
-    percent_bar_config_t *config)
-{
-    init_twidget(percent_bar);
-    percent_bar->size.y = 1;
-    percent_bar->data = (void *)data;
-    percent_bar->config = (void *)config;
-    percent_bar->update = _update_percent_bar;
-    percent_bar->draw_self = _draw_percent_bar;
-}
-
-void init_percent_bar_twidget_container(
-    percent_bar_twidget_container_t *container)
-{
-    init_percent_bar_config(&container->config);
-    init_percent_bar_data(&container->data);
-    init_percent_bar_twidget(
-        &container->widget,
-        &container->data,
-        &container->config);
 }

--- a/eco_perf/cute_terminal/widgets/percent_bar.h
+++ b/eco_perf/cute_terminal/widgets/percent_bar.h
@@ -4,21 +4,16 @@
 #include "../tools/percent_bar.h"
 #include "twidget.h"
 
-typedef twidget_t percent_bar_twidget_t;
-
-void init_percent_bar_twidget(
-    percent_bar_twidget_t *percent_bar,
-    percent_bar_data_t *data,
-    percent_bar_config_t *config);
-
-typedef struct PercentBarTwidgetContainer
+typedef struct PercentBarTManager
 {
-    percent_bar_twidget_t widget;
+    twidget_t twidget;
     percent_bar_config_t config;
     percent_bar_data_t data;
-} percent_bar_twidget_container_t;
+} percent_bar_tmanager_t;
 
-void init_percent_bar_twidget_container(
-    percent_bar_twidget_container_t *container);
+extern const twidget_interface_t percent_bar_twidget_interface;
+
+void init_percent_bar_tmanager(
+    percent_bar_tmanager_t *container);
 
 #endif

--- a/eco_perf/cute_terminal/widgets/percent_bar.h
+++ b/eco_perf/cute_terminal/widgets/percent_bar.h
@@ -11,4 +11,14 @@ void init_percent_bar_twidget(
     percent_bar_data_t *data,
     percent_bar_config_t *config);
 
+typedef struct PercentBarTwidgetContainer
+{
+    percent_bar_twidget_t widget;
+    percent_bar_config_t config;
+    percent_bar_data_t data;
+} percent_bar_twidget_container_t;
+
+void init_percent_bar_twidget_container(
+    percent_bar_twidget_container_t *container);
+
 #endif

--- a/eco_perf/cute_terminal/widgets/terminal.c
+++ b/eco_perf/cute_terminal/widgets/terminal.c
@@ -3,7 +3,25 @@
 #include "../terminal/cursor.h"
 #include "../terminal/window.h"
 
-void _update_terminal(terminal_twidget_t *terminal)
+void _update_terminal(twidget_t *terminal);
+void _draw_terminal(twidget_t *terminal);
+
+const twidget_interface_t terminal_twidget_interface = {
+    _update_terminal,
+    _draw_terminal,
+    default_twidget_free};
+
+void init_terminal_tmanager(
+    terminal_tmanager_t *terminal,
+    twidget_t *main_twidget)
+{
+    twidget_t *term_twidget = &terminal->terminal_container_twidget;
+    init_twidget(term_twidget);
+    term_twidget->interface = &terminal_twidget_interface;
+    add_twidget_child(term_twidget, main_twidget);
+}
+
+void _update_terminal(twidget_t *terminal)
 {
     terminal_window_t terminal_window;
     init_terminal_window(&terminal_window);
@@ -19,20 +37,7 @@ void _update_terminal(terminal_twidget_t *terminal)
     terminal->children.widgets[0]->size = terminal->size;
 }
 
-int _draw_terminal(terminal_twidget_t const *terminal)
+void _draw_terminal(twidget_t *terminal)
 {
     clear_terminal();
-    return 1;
-}
-
-void init_terminal_twidget(
-    terminal_twidget_t *terminal,
-    twidget_t *main_widget)
-{
-    init_twidget(terminal);
-    add_twidget_child(terminal, main_widget);
-    terminal->update = _update_terminal;
-    terminal->draw_self = _draw_terminal;
-
-    terminal->update(terminal);
 }

--- a/eco_perf/cute_terminal/widgets/terminal.h
+++ b/eco_perf/cute_terminal/widgets/terminal.h
@@ -3,10 +3,16 @@
 
 #include "twidget.h"
 
-typedef twidget_t terminal_twidget_t;
+typedef struct TerminalTManager
+{
+    twidget_t terminal_container_twidget;
+    twidget_t *main_twidget;
+} terminal_tmanager_t;
 
-void init_terminal_twidget(
-    terminal_twidget_t *terminal,
-    twidget_t *main_drawable);
+extern const twidget_interface_t terminal_twidget_interface;
+
+void init_terminal_tmanager(
+    terminal_tmanager_t *terminal,
+    twidget_t *main_twidget);
 
 #endif

--- a/eco_perf/cute_terminal/widgets/text_line.c
+++ b/eco_perf/cute_terminal/widgets/text_line.c
@@ -3,17 +3,23 @@
 #include "../terminal/cursor.h"
 #include <stdio.h>
 
-void _update_line_widget(text_line_twidget_t *line_widget);
-int _draw_line_widget(text_line_twidget_t const *line_widget);
+void _draw_line_widget(twidget_t *line_widget);
 
-void init_text_line_twidget(
-    text_line_twidget_t *widget,
-    text_line_twidget_data_t *data)
+const twidget_interface_t text_line_twidget_interface = {
+    default_twidget_update,
+    _draw_line_widget,
+    default_twidget_free};
+
+void init_text_line_tmanager(
+    text_line_tmanager_t *manager)
 {
+    twidget_t *widget = &manager->twidget;
     init_twidget(widget);
-    widget->data = (void *)data;
-    widget->update = _update_line_widget;
-    widget->draw_self = _draw_line_widget;
+    init_text_line_twidget_data(&manager->data);
+    init_text_line_twidget_config(&manager->config);
+    widget->data = (void *)&manager->data;
+    widget->config = (void *)&manager->config;
+    widget->interface = &text_line_twidget_interface;
 }
 
 void init_text_line_twidget_data(text_line_twidget_data_t *data)
@@ -22,24 +28,23 @@ void init_text_line_twidget_data(text_line_twidget_data_t *data)
     data->_effective_line_length = 0;
 }
 
-void set_text_line_twidget_data(
-    text_line_twidget_t *line_widget,
+void init_text_line_twidget_config(text_line_twidget_config_t *config)
+{
+}
+
+void set_text_line_content(
+    text_line_tmanager_t *line_manager,
     char const *line)
 {
-    text_line_twidget_data_t *data = (text_line_twidget_data_t *)line_widget->data;
+    text_line_twidget_data_t *data = &line_manager->data;
     data->_line = line;
     data->_effective_line_length = get_effective_string_length(line);
-    line_widget->size.x = data->_effective_line_length;
+    line_manager->twidget.size.x = data->_effective_line_length;
 }
 
-void _update_line_widget(text_line_twidget_t *line_widget)
-{
-}
-
-int _draw_line_widget(text_line_twidget_t const *line_widget)
+void _draw_line_widget(twidget_t *line_widget)
 {
     text_line_twidget_data_t *data = (text_line_twidget_data_t *)line_widget->data;
     printf("%s", data->_line);
     move_cursor_left(data->_effective_line_length);
-    return 1;
 }

--- a/eco_perf/cute_terminal/widgets/text_line.c
+++ b/eco_perf/cute_terminal/widgets/text_line.c
@@ -17,6 +17,9 @@ void init_text_line_tmanager(
     init_twidget(widget);
     init_text_line_twidget_data(&manager->data);
     init_text_line_twidget_config(&manager->config);
+    widget->size.y = 1;
+    widget->fixed_size.x = 1;
+    widget->fixed_size.y = 1;
     widget->data = (void *)&manager->data;
     widget->config = (void *)&manager->config;
     widget->interface = &text_line_twidget_interface;

--- a/eco_perf/cute_terminal/widgets/text_line.h
+++ b/eco_perf/cute_terminal/widgets/text_line.h
@@ -3,22 +3,34 @@
 
 #include "twidget.h"
 
-typedef twidget_t text_line_twidget_t;
-
 typedef struct TextLineTWidgetData
 {
     char const *_line;
     int _effective_line_length;
 } text_line_twidget_data_t;
 
-void init_text_line_twidget(
-    text_line_twidget_t *widget,
-    text_line_twidget_data_t *data);
+typedef struct TextLineTWidgetConfig
+{
+
+} text_line_twidget_config_t;
+
+typedef struct TextLineTManager
+{
+    twidget_t twidget;
+    text_line_twidget_data_t data;
+    text_line_twidget_config_t config;
+} text_line_tmanager_t;
+
+extern const twidget_interface_t text_line_twidget_interface;
+
+void init_text_line_tmanager(
+    text_line_tmanager_t *manager);
 
 void init_text_line_twidget_data(text_line_twidget_data_t *data);
+void init_text_line_twidget_config(text_line_twidget_config_t *config);
 
-void set_text_line_twidget_data(
-    text_line_twidget_t *line_widget,
+void set_text_line_content(
+    text_line_tmanager_t *line_manager,
     char const *line);
 
 #endif

--- a/eco_perf/cute_terminal/widgets/twidget.c
+++ b/eco_perf/cute_terminal/widgets/twidget.c
@@ -51,6 +51,7 @@ void init_twidget(twidget_t *widget)
     init_term_vector(&widget->fixed_size);
     init_twidget_array(&widget->children);
     widget->config = NULL;
+    widget->free = NULL;
 
     widget->get_origin = _default_get_origin;
     widget->update = _default_update;
@@ -135,13 +136,20 @@ void remove_twidget_child(
 
 void free_twidget(twidget_t *widget)
 {
-    if (!widget->children.widgets)
+    if (!widget)
     {
         return;
     }
-    for (int i = 0; i != widget->children.size; ++i)
+    if (widget->children.widgets)
     {
-        free_twidget(widget->children.widgets[i]);
+        for (int i = 0; i != widget->children.size; ++i)
+        {
+            free_twidget(widget->children.widgets[i]);
+        }
+        free_twidget_array(&widget->children);
     }
-    free_twidget_array(&widget->children);
+    if (widget->free)
+    {
+        widget->free(widget);
+    }
 }

--- a/eco_perf/cute_terminal/widgets/twidget.c
+++ b/eco_perf/cute_terminal/widgets/twidget.c
@@ -4,14 +4,10 @@
 #include <stddef.h>
 #include <string.h>
 
-void _default_update(twidget_t *widget);
-void _default_draw(twidget_t *widget);
-void _default_free(twidget_t *widget);
-
 const twidget_interface_t default_twidget_interface = {
-    _default_update,
-    _default_draw,
-    _default_free};
+    default_twidget_update,
+    default_twidget_draw,
+    default_twidget_free};
 
 twidget_update_function_t get_twidget_update_function(
     twidget_t const *widget)
@@ -50,18 +46,6 @@ void apply_twidget_layout(twidget_t *widget)
     {
         widget->layout->apply_layout(widget->layout, widget);
     }
-}
-
-void _default_update(twidget_t *widget)
-{
-}
-
-void _default_draw(twidget_t *widget)
-{
-}
-
-void _default_free(twidget_t *widget)
-{
 }
 
 void init_twidget(twidget_t *widget)

--- a/eco_perf/cute_terminal/widgets/twidget.c
+++ b/eco_perf/cute_terminal/widgets/twidget.c
@@ -33,6 +33,11 @@ void init_term_vector(terminal_vector_t *vector)
     vector->y = 0;
 }
 
+void init_tmanager(tmanager_t *manager)
+{
+    init_twidget(&manager->twidget);
+}
+
 void set_twidget_layout(
     twidget_t *widget,
     twidget_layout_t *layout)

--- a/eco_perf/cute_terminal/widgets/twidget.h
+++ b/eco_perf/cute_terminal/widgets/twidget.h
@@ -4,6 +4,7 @@
 #include "../terminal/vector.h"
 #include "../tools/twidget_array.h"
 #include "layouts/layout.h"
+#include "twidget_interface.h"
 
 #define DEF_TERMINAL_VECTOR(name) \
     union                         \
@@ -17,41 +18,33 @@ typedef struct TWidget
     int hidden;
     int floating;
 
-    twidget_layout_t *layout;
-
     DEF_TERMINAL_VECTOR(pos);
     DEF_TERMINAL_VECTOR(size);
     DEF_TERMINAL_VECTOR(fixed_size);
 
+    twidget_layout_t *layout; // layout for the widget, can be null
+
+    void *config;                         // possible additional config
+    void *data;                           // possible additional data
+    twidget_interface_t const *interface; // interface functions
+
     struct TWidget *parent;
     twidget_array_t children;
-
-    void *config; // possible additional config
-    void *data;   // possible additional data
-
-    void (*update)(struct TWidget *widget);
-
-    terminal_vector_t (*get_origin)(
-        struct TWidget const *widget);
-
-    int (*draw_self)(struct TWidget const *widget);
-
-    void (*free)(struct TWidget *widget);
 } twidget_t;
 
 void init_twidget(twidget_t *widget);
-
-terminal_vector_t get_default_twidget_origin();
 
 void set_twidget_layout(
     twidget_t *widget,
     twidget_layout_t *layout);
 
-void apply_twidget_layout(twidget_t *widget);
-
 void update_twidget(twidget_t *widget);
 
 int draw_twidget(twidget_t *widget);
+
+void free_twidget(twidget_t *widget);
+
+void apply_twidget_layout(twidget_t *widget);
 
 void add_twidget_child(
     twidget_t *parent,
@@ -66,7 +59,14 @@ void remove_twidget_child(
     twidget_t *child,
     int free_child);
 
-void free_twidget(twidget_t *widget);
+extern const twidget_interface_t default_twidget_interface;
+
+typedef struct TManager
+{
+    twidget_t twidget;
+} tmanager_t;
+
+void init_tmanager(tmanager_t *manager);
 
 #undef DEF_TERMINAL_VECTOR
 

--- a/eco_perf/cute_terminal/widgets/twidget.h
+++ b/eco_perf/cute_terminal/widgets/twidget.h
@@ -35,6 +35,8 @@ typedef struct TWidget
         struct TWidget const *widget);
 
     int (*draw_self)(struct TWidget const *widget);
+
+    void (*free)(struct TWidget *widget);
 } twidget_t;
 
 void init_twidget(twidget_t *widget);

--- a/eco_perf/cute_terminal/widgets/twidget_interface.c
+++ b/eco_perf/cute_terminal/widgets/twidget_interface.c
@@ -1,0 +1,13 @@
+#include "twidget_interface.h"
+
+void default_twidget_update(struct TWidget *widget)
+{
+}
+
+void default_twidget_draw(struct TWidget *widget)
+{
+}
+
+void default_twidget_free(struct TWidget *widget)
+{
+}

--- a/eco_perf/cute_terminal/widgets/twidget_interface.h
+++ b/eco_perf/cute_terminal/widgets/twidget_interface.h
@@ -1,0 +1,17 @@
+#ifndef CUTE_TERMINAL_TWIDGET_INTERFACE_H_INCLUDED
+#define CUTE_TERMINAL_TWIDGET_INTERFACE_H_INCLUDED
+
+struct TWidget;
+
+typedef struct TWidgetInterface
+{
+
+    void (*update)(struct TWidget *twidget);
+
+    void (*draw)(struct TWidget *twidget);
+
+    void (*release)(struct TWidget *twidget);
+
+} twidget_interface_t;
+
+#endif

--- a/eco_perf/cute_terminal/widgets/twidget_interface.h
+++ b/eco_perf/cute_terminal/widgets/twidget_interface.h
@@ -16,4 +16,8 @@ typedef struct TWidgetInterface
 
 } twidget_interface_t;
 
+void default_twidget_update(struct TWidget *widget);
+void default_twidget_draw(struct TWidget *widget);
+void default_twidget_free(struct TWidget *widget);
+
 #endif

--- a/eco_perf/cute_terminal/widgets/twidget_interface.h
+++ b/eco_perf/cute_terminal/widgets/twidget_interface.h
@@ -3,14 +3,16 @@
 
 struct TWidget;
 
+typedef void (*twidget_update_function_t)(struct TWidget *);
+typedef void (*twidget_draw_function_t)(struct TWidget *);
+typedef void (*twidget_free_function_t)(struct TWidget *);
+
 typedef struct TWidgetInterface
 {
 
-    void (*update)(struct TWidget *twidget);
-
-    void (*draw)(struct TWidget *twidget);
-
-    void (*release)(struct TWidget *twidget);
+    twidget_update_function_t update;
+    twidget_draw_function_t draw;
+    twidget_free_function_t free;
 
 } twidget_interface_t;
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,5 +1,3 @@
-
-
 add_executable(test_drawable test_drawable.c)
 target_link_libraries(test_drawable eco_perf)
 

--- a/tests/answer_test_box.c
+++ b/tests/answer_test_box.c
@@ -10,49 +10,42 @@ int main()
 {
     // Init the application and the main widget
     terminal_application_t app;
-    twidget_t main_widget;
-    init_twidget(&main_widget);
-    init_terminal_application(&app, &main_widget);
+    tmanager_t main_manager;
+    init_tmanager(&main_manager);
+    init_terminal_application(&app, &main_manager.twidget);
     app.sleep_duration = 0.5; // time between two iterations
 
     // Set layout for main widget
     twidget_linear_layout_t main_layout;
     init_twidget_linear_layout(&main_layout, CT_VERTICAL);
-    set_twidget_layout(&main_widget, &main_layout);
+    set_twidget_layout(&main_manager.twidget, &main_layout);
     main_layout.config.auto_children_resize = 0;
     main_layout.config.vertical_align_mode = CT_CENTER;
     main_layout.config.horizontal_align_mode = CT_CENTER;
 
     // Init the box widget, with a fixed size
     // (the layout will not stretch it, only center it)
-    box_twidget_t box;
-    init_box_twidget(&box);
-    set_terminal_vector(&box.size, 40, 5);
-    add_twidget_child(&main_widget, &box);
+    box_tmanager_t box;
+    init_box_tmanager(&box);
+    set_terminal_vector(&box.twidget.size, 40, 10);
+    add_twidget_child(&main_manager.twidget, &box.twidget);
 
     // Set the box layout: vertical layout (title and one percent bar)
     twidget_linear_layout_t box_layout;
     init_twidget_linear_layout(&box_layout, CT_VERTICAL);
     box_layout.config.spacing = 1; // Set one line spacing
-    set_twidget_layout(&box, &box_layout);
+    set_twidget_layout(&box.twidget, &box_layout);
 
     // Define title for the box
-    text_line_twidget_t box_title;
-    text_line_twidget_data_t title_data;
-    init_text_line_twidget_data(&title_data);
-    init_text_line_twidget(&box_title, &title_data);
-    box_title.fixed_size.x = 1;
-    add_twidget_child(&box, &box_title);
+    text_line_tmanager_t box_title;
+    init_text_line_tmanager(&box_title);
+    add_twidget_child(&box.twidget, &box_title.twidget);
 
     // Define cpu_bar widget with dummy data (does not change)
-    percent_bar_twidget_t cpu_bar;
-    percent_bar_data_t cpu_data;
-    init_percent_bar_data(&cpu_data);
-    add_percent_data(&cpu_data, 0., CT_GREEN);
-    percent_bar_config_t cpu_config;
-    init_percent_bar_config(&cpu_config);
-    init_percent_bar_twidget(&cpu_bar, &cpu_data, &cpu_config);
-    add_twidget_child(&box, &cpu_bar);
+    percent_bar_tmanager_t cpu_bar;
+    init_percent_bar_tmanager(&cpu_bar);
+    add_twidget_child(&box.twidget, &cpu_bar.twidget);
+    add_percent_data(&cpu_bar.data, 0., CT_GREEN);
 
     const float n_seconds_sleep = 0.5;
     int index = 0;
@@ -63,15 +56,15 @@ int main()
     {
         if (index % 2 == 0)
         {
-            set_text_line_twidget_data(&box_title, "Tu y arrivera aurelien!");
+            set_text_line_content(&box_title, "Tu y arrivera aurelien!");
         }
         else
         {
-            set_text_line_twidget_data(&box_title, "Ou pas ... :)))))))");
+            set_text_line_content(&box_title, "Ou pas ... :)))))))");
         }
         double percent = 20 * index / 100.;
-        cpu_data.data[0] = percent;
-        cpu_data.colors[0] = colors[color_index % n_colors];
+        cpu_bar.data.data[0] = percent;
+        cpu_bar.data.colors[0] = colors[color_index % n_colors];
         update_terminal_application(&app);
         ++index;
         if (percent >= 1)
@@ -80,4 +73,5 @@ int main()
             ++color_index;
         }
     }
+    free_terminal_application(&app);
 }

--- a/tests/test_box.c
+++ b/tests/test_box.c
@@ -26,15 +26,15 @@ int main()
 
     // Init the application and the main widget
     terminal_application_t app;
-    box_twidget_t main_widget;
-    init_box_twidget(&main_widget);
-    init_terminal_application(&app, &main_widget);
+    box_tmanager_t main_manager;
+    init_box_tmanager(&main_manager);
+    init_terminal_application(&app, &main_manager.twidget);
 
     // Set layout for main widget. It should not resize the box,
     // only center it.
     twidget_linear_layout_t main_layout;
     init_twidget_linear_layout(&main_layout, CT_VERTICAL);
-    set_twidget_layout(&main_widget, &main_layout);
+    set_twidget_layout(&main_manager.twidget, &main_layout);
 
     while (1)
     {

--- a/tests/test_drawable.c
+++ b/tests/test_drawable.c
@@ -2,6 +2,7 @@
 #include "eco_perf/cute_terminal/widgets/box.h"
 #include "eco_perf/cute_terminal/widgets/twidget.h"
 #include <stdio.h>
+#include <stdlib.h>
 #include <sys/ioctl.h>
 #include <unistd.h>
 
@@ -19,49 +20,53 @@ void print_drawable(twidget_t *drawable)
 
 void test_boxes()
 {
-    box_twidget_t bigger_box;
+    box_tmanager_t bigger_box;
     terminal_vector_t pos, size;
     pos.x = 10;
     pos.y = 5;
     size.x = 100;
-    size.y = 100;
-    init_box_twidget(&bigger_box);
+    size.y = 10;
+    init_box_tmanager(&bigger_box);
+    bigger_box.twidget.pos = pos;
+    bigger_box.twidget.size = size;
 
     clear_terminal();
-    box_twidget_t box1, box2, box3;
+    box_tmanager_t box1, box2, box3;
+    init_box_tmanager(&box1);
+    init_box_tmanager(&box2);
+    init_box_tmanager(&box3);
 
     pos.x = 0;
     pos.y = 1;
     size.x = 5;
     size.y = 5;
-    init_box_twidget(&box1);
+    box1.twidget.pos = pos;
+    box1.twidget.size = size;
 
     pos.x += 10;
-    size.x += 30;
-    box_twidget_config_t config_box2;
-    init_box_twidget(&box2);
-    config_box2.background = 'x';
-    box2.config = (void *)(&config_box2);
+    size.x += 2;
+    box2.twidget.pos = pos;
+    box2.twidget.size = size;
+    box2.config.background = 'x';
 
     pos.x = 3;
     pos.y = 4;
     size.x = 20;
-    size.y = 10;
-    box_twidget_config_t config_box3;
-    config_box3.background = '*';
-    init_box_twidget(&box3);
-    box3.config = (void *)(&config_box3);
+    size.y = 8;
+    box3.twidget.pos = pos;
+    box3.twidget.size = size;
+    box3.config.background = '*';
 
-    add_twidget_child(&bigger_box, &box1);
-    add_twidget_child(&bigger_box, &box2);
-    add_twidget_child(&bigger_box, &box3);
+    add_twidget_child(&bigger_box.twidget, &box1.twidget);
+    add_twidget_child(&bigger_box.twidget, &box2.twidget);
+    add_twidget_child(&bigger_box.twidget, &box3.twidget);
 
-    draw_twidget(&bigger_box);
+    draw_twidget(&bigger_box.twidget);
     char c;
     scanf("%c", &c);
 }
 
-int main()
+int main(int argc, char const *argv[])
 {
     twidget_t terminal;
     init_twidget(&terminal);
@@ -98,7 +103,10 @@ int main()
     printf("lines %d\n", w.ws_row);
     printf("columns %d\n", w.ws_col);
 
-    // test_boxes();
+    if (argc > 1 && atoi(argv[1]))
+    {
+        test_boxes();
+    }
 
     return 0;
 }


### PR DESCRIPTION
The polymorphism necessary for the widget system to work has the consequence to require a lot of lines of code to define all the necessary objects on the stack (or allocate a lot of different objects, complicating the code and the user interface).

This PR modifies the behavior of `cute-terminal` in the following way:
 - Now only one container per widget must be created on the stack (or allocated by the user if necessary)
 - The container contains the widget, data and configuration accessible safely and directly by the user.
 - The container initialization takes car of initializing al members correctly in a unique C source file.

The user interface should therefore resemble something like
``` c
    twidget_container_1_t container_1;
    init_twidget_container_1(&container_1);
    container_1.config.layout.spacing = 3; 

    twidget_container_2_t container_2;
    init_twidget_container_2(&container_2);
    container_2.data.title = "Some title for my widget";

    add_twidget_child(&container_1.twidget, &container_2.twidget);
    // etc
```